### PR TITLE
extrae: relax requirements on binutils

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -82,7 +82,8 @@ class Extrae(AutotoolsPackage):
     depends_on("elf", type="link")
     depends_on("libxml2")
     depends_on("numactl")
-    depends_on("binutils+libiberty@:2.33")
+    depends_on("binutils+libiberty@:2.33", when="@:4.0.1")
+    depends_on("binutils+libiberty", when="@4.0.2:")
     depends_on("gettext")
     # gettext dependency added to find -lintl
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Small update on Extrae recipe. Older version of Extrae had issues with certain versions of binutils. This has been addressed a while ago. 

This pull request update the recipe to reflect those developments.